### PR TITLE
Help with compiling error and warning 

### DIFF
--- a/codedemo/headerdemo.c
+++ b/codedemo/headerdemo.c
@@ -13,6 +13,7 @@
 #include <err.h>
 #include <assert.h>
 #include <getopt.h>
+#include <stdlib.h>
 
 uint64_t udp_header = 0;
 uint64_t udp_payload = 0;

--- a/codedemo/sourcedemo.c
+++ b/codedemo/sourcedemo.c
@@ -16,7 +16,7 @@
  * effective. Libtrace will have provided us a pointer to the start of the
  * MAC address within the packet, so we can just use array indices to grab
  * each byte of the MAC address in turn */
-inline void print_mac(uint8_t *mac) {
+static inline void print_mac(uint8_t *mac) {
 
 	printf("%02x:%02x:%02x:%02x:%02x:%02x ", mac[0], mac[1], mac[2], mac[3],
 		mac[4], mac[5]);
@@ -25,7 +25,7 @@ inline void print_mac(uint8_t *mac) {
 
 /* Given a sockaddr containing an IP address, prints the IP address to stdout
  * using the common string representation for that address type */
-inline void print_ip(struct sockaddr *ip) {
+static inline void print_ip(struct sockaddr *ip) {
 
 	char str[20];
 	

--- a/codedemo/yk_sourcedemo.c
+++ b/codedemo/yk_sourcedemo.c
@@ -16,7 +16,7 @@
  * effective. Libtrace will have provided us a pointer to the start of the
  * MAC address within the packet, so we can just use array indices to grab
  * each byte of the MAC address in turn */
-inline void print_mac(uint8_t *mac) {
+static inline void print_mac(uint8_t *mac) {
 
 	printf("%02x:%02x:%02x:%02x:%02x:%02x ", mac[0], mac[1], mac[2], mac[3],
 		mac[4], mac[5]);
@@ -25,7 +25,7 @@ inline void print_mac(uint8_t *mac) {
 
 /* Given a sockaddr containing an IP address, prints the IP address to stdout
  * using the common string representation for that address type */
-inline void print_ip(struct sockaddr *ip) {
+static inline void print_ip(struct sockaddr *ip) {
 
 	char str[20];
 	struct in_addr source_ip_addr;//yk

--- a/hw0/yk_demo_hash.c
+++ b/hw0/yk_demo_hash.c
@@ -105,11 +105,11 @@ void per_packet(libtrace_packet_t *packet)
 	//******************
 	payload_length=trace_get_payload_length(packet);
 	frame_length=trace_get_framing_length(packet);
-	printf("frame_Length=%d\n",frame_length);
+	printf("frame_Length=%ld\n",frame_length);
 	if (payload_length == 0) 
 		printf("can not get payload length");
 	else
-		printf("payload_Length=%d\n",payload_length);	
+		printf("payload_Length=%ld\n",payload_length);	
 
 	/* Get the source IP address */
 	/* Note that we pass a casted sockaddr_storage into this function. This

--- a/hw0/yk_demo_hash.c
+++ b/hw0/yk_demo_hash.c
@@ -37,7 +37,7 @@
  * effective. Libtrace will have provided us a pointer to the start of the
  * MAC address within the packet, so we can just use array indices to grab
  * each byte of the MAC address in turn */
-inline void print_mac(uint8_t *mac) {
+static inline void print_mac(uint8_t *mac) {
 
 	printf("%02x:%02x:%02x:%02x:%02x:%02x \n", mac[0], mac[1], mac[2], mac[3],
 		mac[4], mac[5]);
@@ -46,7 +46,7 @@ inline void print_mac(uint8_t *mac) {
 
 /* Given a sockaddr containing an IP address, prints the IP address to stdout
  * using the common string representation for that address type */
-inline void print_ip(struct sockaddr *ip) {
+static inline void print_ip(struct sockaddr *ip) {
 
 	char str[20];
 	struct in_addr source_ip_addr;//yk

--- a/lib/massdal/countmin.c
+++ b/lib/massdal/countmin.c
@@ -104,8 +104,14 @@ void CM_Destroy(CM_type * cm)
       free(cm->counts);
       cm->counts=NULL;
     }
-  if (cm->hasha) free(cm->hasha); cm->hasha=NULL;
-  if (cm->hashb) free(cm->hashb); cm->hashb=NULL;
+  if (cm->hasha) {
+      free(cm->hasha);
+      cm->hasha=NULL;
+  }
+  if (cm->hashb) {
+      free(cm->hashb);
+      cm->hashb=NULL;
+  }
   free(cm);  cm=NULL;
 }
 
@@ -309,8 +315,14 @@ void CMF_Destroy(CMF_type * cm)
       free(cm->counts);
       cm->counts=NULL;
     }
-  if (cm->hasha) free(cm->hasha); cm->hasha=NULL;
-  if (cm->hashb) free(cm->hashb); cm->hashb=NULL;
+  if (cm->hasha) {
+      free(cm->hasha);
+      cm->hasha=NULL;
+  }
+  if (cm->hashb) {
+      free(cm->hashb);
+      cm->hashb=NULL;
+  }
   free(cm);  cm=NULL;
 }
 

--- a/lib/massdal/hotitems.c
+++ b/lib/massdal/hotitems.c
@@ -178,7 +178,7 @@ int RunExact(int thresh)
 {
   int i,hh, sum, j;
   StartTheClock();
-  hh=0; sum=-1, j;
+  hh=0; sum=-1;
 
   j=0; sumsq=0;
   for (i=0;i<n;i++) 
@@ -197,7 +197,7 @@ int RunExact(int thresh)
 	  hh++;
 	}
     }
-  printf("Exact used %d bytes, took %ld ms.  Zipfparam = %f\n",
+  printf("Exact used %ld bytes, took %ld ms.  Zipfparam = %f\n",
   n*sizeof(int),StopTheClock(),zipfpar);
   printf("There were %d items above threshold of %d, for phi=%f, n=%d\n",
 	 hh,thresh,phi, range);
@@ -247,7 +247,7 @@ int main(int argc, char **argv)
       CMH_Update(cmh,-stream[i],-1);      
   uptime=StopTheClock();
   StartTheClock();
-  uilist=CMH_FindHH(cmh,thresh);
+  uilist=(unsigned int *)CMH_FindHH(cmh,thresh);
   outtime=StopTheClock(); 
   CheckOutput("CM",uilist,thresh,hh, uptime, outtime, CMH_Size(cmh));
   free(uilist);

--- a/lib/massdal/prng.c
+++ b/lib/massdal/prng.c
@@ -206,7 +206,7 @@ void RanrotAInit (prng_type * prng, unsigned long seed) {
 
   /* randomize */
   for (i = 0;  i < 300;  i++) ran3(prng);
-  prng->scale = ldexp(1, -8*sizeof(unsigned long));
+  prng->scale = ldexp(1, -8*(long)sizeof(unsigned long));
 }
 
 


### PR DESCRIPTION
Original compiler warning:

```bash
gcc  -o yk_demo_hash yk_demo_hash.c ../lib/massdal/prng.c -ltrace -lm
yk_demo_hash.c: In function ‘per_packet’:
yk_demo_hash.c:108:31: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
  108 |         printf("frame_Length=%d\n",frame_length);
      |                              ~^    ~~~~~~~~~~~~
      |                               |    |
      |                               int  size_t {aka long unsigned int}
      |                              %ld
yk_demo_hash.c:112:41: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
  112 |                 printf("payload_Length=%d\n",payload_length);
      |                                        ~^    ~~~~~~~~~~~~~~
      |                                         |    |
      |                                         int  size_t {aka long unsigned int}
      |                                        %ld
```

Tested fix on WSL2 Ubuntu 22.04.