### PR TITLE
[Severity: Middle] Move param value check to common_functions.sh with co…

### DIFF
--- a/setup/common_functions.sh
+++ b/setup/common_functions.sh
@@ -29,6 +29,15 @@ load_preset () {
     check_var script_stat                   $error_exit_code
 
     if [ $verbose == 1 ]; then
+        echo_notice "$message1" "$message2" "Checking variable values"
+    fi
+    #[ PARAM - TASKS ] X 5(skip)
+    #[ PARAM - EXECUTION MODE ] X 1
+    if [ $script_stat != "dev" ] && [ $script_stat != "prod" ]; then
+        echo_error "$message1" "$message2" "Invalid script_stat: should be either dev or prod" $error_exit_code
+    fi
+
+    if [ $verbose == 1 ]; then
         echo_notice "$message1" "$message2" "Setting private variables"
     fi
     wget_flags="-nv --show-progress"
@@ -55,9 +64,6 @@ load_preset () {
         :
     elif [ $script_stat == "prod" ]; then
         make_flags="-j$(nproc)"
-    else
-        echo_error "$message1" "$message2" "Invalid script_stat"
-        exit $error_exit_code
     fi
     libwandder_file="${libwandder_name}-${libwandder_release_url##*/}"
     libwandder_ln="${libwandder_file//.tar.gz}"

--- a/setup/common_functions.sh
+++ b/setup/common_functions.sh
@@ -46,6 +46,7 @@ load_preset () {
     program_install_dir="/opt"
     system_include_dir="/usr/local/include"
     system_lib_dir="/usr/local/lib"
+    system_share_dir="/usr/local/share"
     uthash_repo_url="https://github.com/troydhanson/uthash.git"
     uthash_name="uthash"
     libwandder_release_url="https://github.com/LibtraceTeam/libwandder/archive/refs/tags/2.0.11-1.tar.gz"

--- a/setup/remove.sh
+++ b/setup/remove.sh
@@ -42,8 +42,8 @@ fi
 msg="remove libwandder"
 if [ $task_libwandder == 1 ]; then
     echo_notice "$this_script" "$msg" "Removing libwandder"
-    sudo rm -f ${system_include_dir}/libwandder*.h
-    sudo rm -f ${system_lib_dir}/libwandder*
+    cd "${program_install_dir}/${libwandder_name}"
+    sudo make uninstall
     sudo rm -f "${program_install_dir}/${libwandder_file}"
     sudo rm -rf "${program_install_dir}/${libwandder_ln}"
     sudo rm -f "${program_install_dir}/${libwandder_name}"
@@ -55,8 +55,8 @@ fi
 msg="remove wandio"
 if [ $task_wandio == 1 ]; then
     echo_notice "$this_script" "$msg" "Removing wandio"
-    sudo rm -f ${system_include_dir}/wandio*.h
-    sudo rm -f ${system_lib_dir}/libwandio*
+    cd "${program_install_dir}/${wandio_name}"
+    sudo make uninstall
     sudo rm -f "${program_install_dir}/${wandio_file}"
     sudo rm -rf "${program_install_dir}/${wandio_ln}"
     sudo rm -f "${program_install_dir}/${wandio_name}"
@@ -68,11 +68,11 @@ fi
 msg="remove libtrace"
 if [ $task_libtrace == 1 ]; then
     echo_notice "$this_script" "$msg" "Removing libtrace"
-    sudo rm -f ${system_include_dir}/libtrace*.h
-    sudo rm -f ${system_include_dir}/libpacketdump*.h
-    sudo rm -rf "${system_include_dir}/${libtrace_name}"
-    sudo rm -f ${system_lib_dir}/libtrace*
-    sudo rm -rf ${system_lib_dir}/libpacketdump*
+    cd "${program_install_dir}/${libtrace_name}"
+    sudo make uninstall
+    sudo rm -rf "${system_lib_dir}/libpacketdump"
+    sudo rmdir "${system_include_dir}/${libtrace_name}"
+    sudo rmdir "${system_share_dir}/${libtrace_name}"
     sudo rm -f "${program_install_dir}/${libtrace_file}"
     sudo rm -rf "${program_install_dir}/${libtrace_ln}"
     sudo rm -f "${program_install_dir}/${libtrace_name}"

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -11,17 +11,17 @@
 bash_function_url="https://raw.githubusercontent.com/belongtothenight/bash_scripts/main/src/functions.sh"
 bash_function_file="./functions.sh"
 
-echo "Updating system package"
+echo ">> Updating system package"
 sudo apt update || { echo 'apt update failed' ; exit 1; }
 sudo apt upgrade -y || { echo 'apt upgrade failed' ; exit 1; }
 
-echo "Installing mutual dependencies"
+echo ">> Installing mutual dependencies"
 sudo apt install -y build-essential git wget || { echo 'apt failed' ; exit 1; }
 
-echo "Downloading bash functions"
+echo ">> Downloading bash functions"
 sudo wget -nv --show-progress ${bash_function_url} --output-document ${bash_function_file} || { echo 'wget failed'; exit 1; }
 
-echo "Sourcing bash functions"
+echo ">> Sourcing bash functions"
 source "${bash_function_file}" || { echo 'source failed'; exit 1; } # Enter fail-exit mode
 source "./common_functions.sh"
 load_preset "./config.ini"
@@ -110,9 +110,6 @@ if [ $task_libtrace == 1 ]; then
         err_retry_exec "aptins libssl-dev"              1 5 "${this_script}" "$msg" 1 # (optional) for libcrypto
         err_retry_exec "aptins libncurses5-dev"         1 5 "${this_script}" "$msg" 1 # (optional) for libncurses
         err_retry_exec "aptins libncursesw5-dev"        1 5 "${this_script}" "$msg" 1 # (optional) for libncurses
-    else
-        echo_error "$this_script" "$msg" "Unknown script_stat"
-        exit 1
     fi
 fi
 
@@ -137,9 +134,6 @@ if [ $task_libwandder == 1 ] || [ $task_wandio == 1 ] || [ $task_libtrace == 1 ]
             err_conti_exec "sudo ln -s ${program_install_dir}/${libwandder_ln} ${program_install_dir}/${libwandder_name}" "${this_script}" "$msg"
         elif [ $script_stat == "prod" ]; then
             sudo ln -s "${program_install_dir}/${libwandder_ln}" "${program_install_dir}/${libwandder_name}"
-        else
-            echo_error "$this_script" "$msg" "Unknown script_stat"
-            exit 1
         fi
     fi
     if [ $task_wandio == 1 ]; then
@@ -147,9 +141,6 @@ if [ $task_libwandder == 1 ] || [ $task_wandio == 1 ] || [ $task_libtrace == 1 ]
             err_conti_exec "sudo ln -s ${program_install_dir}/${wandio_ln} ${program_install_dir}/${wandio_name}" "${this_script}" "$msg"
         elif [ $script_stat == "prod" ]; then
             sudo ln -s "${program_install_dir}/${wandio_ln}" "${program_install_dir}/${wandio_name}"
-        else
-            echo_error "$this_script" "$msg" "Unknown script_stat"
-            exit 1
         fi
     fi
     if [ $task_libtrace == 1 ]; then
@@ -157,9 +148,6 @@ if [ $task_libwandder == 1 ] || [ $task_wandio == 1 ] || [ $task_libtrace == 1 ]
             err_conti_exec "sudo ln -s ${program_install_dir}/${libtrace_ln} ${program_install_dir}/${libtrace_name}" "${this_script}" "$msg"
         elif [ $script_stat == "prod" ]; then
             sudo ln -s "${program_install_dir}/${libtrace_ln}" "${program_install_dir}/${libtrace_name}"
-        else
-            echo_error "$this_script" "$msg" "Unknown script_stat"
-            exit 1
         fi
     fi
 fi


### PR DESCRIPTION
…rrect function usage syntax

Commits from source:
1. ab14cc6228c8b78e134e07fe5e232ab6b0f1770f
2. 5a6a454cbb10726f18a586cb45d1122946639c82
3. 066eb50cb78b213cebe206e9d466867decab538d

Solves:
1. Multiple redundant param value check.
2. Misuse bash function "echo_error".
3. Echo messages hard to see before custom function loads.
4. Use make remove as the main removal command.
5. Remove leftover installed shared library files.